### PR TITLE
Fix SQL query syntax for book name search

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE %s", name
+            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
This pull request makes a small change to the SQL query in the `index` route to modify how books are searched by name. The change updates the query to use string concatenation for the `LIKE` clause instead of a parameterized query.